### PR TITLE
Add missing option to lua-options.md

### DIFF
--- a/content/preferences-settings/lua-options.md
+++ b/content/preferences-settings/lua-options.md
@@ -5,5 +5,10 @@ weight: 140
 draft: false
 ---
 
+Control the behavior of the [Lua scripts installer](../module-reference/utility-modules/lighttable/lua-scripts-installer.md).
+
+lua scripts installer log debug messages
+: Write debugging messages to the log if the -d lua flag is specified
+
 lua scripts installer don't show again
-: Check this box to hide the [lua scripts installer](../module-reference/utility-modules/lighttable/lua-scripts-installer.md) in the lighttable if no lua scripts are installed.
+: Check this box to hide the Lua scripts installer in the lighttable if no lua scripts are installed.


### PR DESCRIPTION
The "lua scripts installer log debug messages" option appears on the UI in darktable 5.0, but it's not in the docs, so I added it.

This option was added to the main project over a year ago (commit 7c5907c) so perhaps this was intentional, but the worst that can happen is this PR just gets closed.

Details:

- Added a header sentence now that there are two options in this file, and hoisted the cross-reference into the header
- Documented the new option (description pulled straight from the [original code commit](https://github.com/darktable-org/darktable/commit/7c5907c345190f2aa35361996eb06fb403bd79f1#diff-045ae140eec0e47f407d1aefad0c1366989f100701b8ab2641aa773c235d1de9R55))
- Changed the capitalization of "Lua" in the two places where it refers to the language rather than the command, to be consistent with the other "Scripting with Lua" documentation